### PR TITLE
autoswitching to hashmap version implemented in pattern function in c…

### DIFF
--- a/R/argchecks_mid.R
+++ b/R/argchecks_mid.R
@@ -227,7 +227,7 @@
     (is.matrix(x) || inherits(x, "sparseMatrix")) &&
     isTRUE(dim(x)[[1]] == dim(x)[[2]]) &&
     Matrix::isSymmetric(x, check.attributes = FALSE) &&
-    all(unique(as.vector(x)) %in% c(0, 1))
+    all(Matrix::Matrix(x, sparse = TRUE)@x %in% c(0, 1))
 }
 .MUST.isAdjacencyMatrix <- function(x, name = NULL) {
   if (is.null(name)) { name <- deparse(substitute(x)) }

--- a/R/network_analysis.R
+++ b/R/network_analysis.R
@@ -32,6 +32,9 @@ generateAdjacencyMatrix <- function(
   method <- .checkMethod(method, dist_cutoff)
   msg <- .makemsg(verbose)
   tmpfile <- tempfile(pattern = "col_ids", fileext = ".txt")
+  if (dist_cutoff == 0) {
+    method <- "pattern"
+  }
   if (dist_type == "levenshtein") {
     msg("Computing network edges based on a max ", dist_type, " distance of ",
         dist_cutoff, "...", newline = FALSE


### PR DESCRIPTION
1) In the case of the distance 0 pattern algorithm just use hashmaps, and there are no issues with memory, while there is a significant speed-up from O(N^2) to O(N) time.  
2) Fix of argcheck function "isAdjacencyMatrix" to avoid memory issues for sparse matrices and speed up.